### PR TITLE
Add presleycollectibles.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -361,6 +361,7 @@ pornogig.com
 pornoklad.ru
 portnoff.od.ua
 pozdravleniya-c.ru
+presleycollectibles.com
 priceg.com
 pricheski-video.com
 prlog.ru


### PR DESCRIPTION
Referrer: https://presleycollectibles.com/store/

The site looks legitimate, but I see this referrer on my Piwik sites which are completely unrelared to what they offer and I can't find any links there that point back to my sites. Most likely scripted spam.

https://user-images.githubusercontent.com/93784/28757916-7debc634-758d-11e7-85bd-6f38fc9139dc.PNG