### PR TITLE
Added renegadetribune.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -404,6 +404,7 @@ rapidsites.pro
 rcb101.ru
 realresultslist.com
 rednise.com
+renegadetribune.com
 replica-watch.ru
 research.ifmo.ru
 resellerclub.com


### PR DESCRIPTION
Although renegadetribune.com seems to be a legitimate website with actual content, it looks like they're using referrer spammer tactics or they've hired a bad SEO/Internet advertiser to promote their site. Either way, their referrers aren't trustworthy.

Their referring page contains no backlinks to my content.  Their site content is completely unrelated to the referent page, so it appears that they randomly picked a recent page from one of my sites to use as the referent.