### PR TITLE
Add prosmibank.ru

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -428,6 +428,7 @@ prodvigator.ua
 prointer.net.ua
 promoforum.ru
 pron.pro
+prosmibank.ru
 psa48.ru
 qualitymarketzone.com
 quit-smoking.ga


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.