### PR TITLE
Add med-dopomoga.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -363,6 +363,7 @@ masterseek.com
 mattgibson.us
 mebelcomplekt.ru
 mebeldekor.com.ua
+med-dopomoga.com
 med-zdorovie.com.ua
 meds-online24.com
 meduza-consult.ru


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.