### PR TITLE
Add columb.net.ua

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -126,6 +126,7 @@ clicksor.com
 club-lukojl.ru
 coderstate.com
 codysbbq.com
+columb.net.ua
 compliance-alex.xyz
 compliance-alexa.xyz
 compliance-andrew.xyz


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.