### PR TITLE
Add hoztorg-opt.ru

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -282,6 +282,7 @@ hosting-tracker.com
 housediz.com
 howopen.ru
 howtostopreferralspam.eu
+hoztorg-opt.ru
 hulfingtonpost.com
 humanorightswatch.org
 hundejo.com


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.