### PR TITLE
Add docs4all.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -193,8 +193,9 @@ dividendo.ru
 djekxa.ru
 djonwatch.ru
 dktr.ru
-documentbase.net
+docs4all.com
 docsarchive.net
+documentbase.net
 documentsite.net
 dogsrun.net
 dojki-hd.com


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.