### PR TITLE
Add kazka.ru

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -337,6 +337,7 @@ kabinet-online-vtb.ru
 kabinet-tinkoff.ru
 kabinet-ttk.ru
 kambasoft.com
+kazka.ru
 kazrent.com
 kerch.site
 keywords-monitoring-success.com


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.