### PR TITLE
Add comp-pomosch.ru

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -153,6 +153,7 @@ codysbbq.com
 coffeemashiny.ru
 columb.net.ua
 commerage.ru
+comp-pomosch.ru
 compliance-alex.xyz
 compliance-alexa.xyz
 compliance-andrew.xyz


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.