### PR TITLE
Add prostitutki-spb.spb.ru

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -572,6 +572,7 @@ prointer.net.ua
 promoforum.ru
 pron.pro
 prosmibank.ru
+prostitutki-spb.spb.ru
 psa48.ru
 qualitymarketzone.com
 quit-smoking.ga


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.