### PR TITLE
Add gandikapper.ru

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -310,6 +310,7 @@ freewlan.info
 freshnails.com.ua
 fsalas.com
 game300.ru
+gandikapper.ru
 gearcraft.us
 gearsadspromo.club
 generalporn.org


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.