### PR TITLE
Add hyip-zanoza.me

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -357,6 +357,7 @@ hulfingtonpost.com
 humanorightswatch.org
 hundejo.com
 hvd-store.com
+hyip-zanoza.me
 ico.re
 igadgetsworld.com
 igru-xbox.net


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.