### PR TITLE
Add sinhronperevod.ru

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -662,6 +662,7 @@ shops-ru.ru
 sibecoprom.ru
 sim-dealer.ru
 simple-share-buttons.com
+sinhronperevod.ru
 site-auditor.online
 site5.com
 siteripz.net


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.