### PR TITLE
Removes e-kwiaciarz.pl

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -247,7 +247,6 @@ dvr.biz.ua
 e-buyeasy.com
 e-commerce-seo.com
 e-commerce-seo1.com
-e-kwiaciarz.pl
 earn-from-articles.com
 easycommerce.cf
 ecommerce-seo.org


### PR DESCRIPTION
We got a request from the owner of this website to remove it from the list.
It seems to be an online flower shop in Poland and unrelated to spam.