### PR TITLE
Add ww2awards.info

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -823,6 +823,7 @@ workius.ru
 works.if.ua
 worldmed.info
 wufak.com
+ww2awards.info
 www-lk-rt.ru
 xkaz.org
 xn-------53dbcapga5atlplfdm6ag1ab1bvehl0b7toa0k.xn--p1ai


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.