### PR TITLE
Add seoservices2018.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -871,3 +871,4 @@ zdorovie-nogi.info
 zelena-mriya.com.ua
 zoominfo.com
 zvetki.ru
+seoservices2018.com


### PR DESCRIPTION
I saw seoservices2018.com showing up as a referrer in Matomo. It seems to redirect to our usual spammers... semalt.com.

Sorry, I just saw the contributing file and I didn't put the website in alphabetical order. It is on the last line of the file.