### PR TITLE
Add computer-remont.ru

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -175,6 +175,7 @@ compliance-irvin.xyz
 compliance-ivan.xyz
 compliance-john.top
 compliance-julianna.top
+computer-remont.ru
 conciergegroup.org
 connectikastudio.com
 cookie-law-enforcement-aa.xyz


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.