### PR TITLE
Add russian-postindex.ru

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -639,6 +639,7 @@ ruinfocomp.ru
 rumamba.com
 rupolitshow.ru
 rusexy.xyz
+russian-postindex.ru
 sad-torg.com.ua
 sady-urala.ru
 saltspray.ru


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.