### PR TITLE
Add balkanfarma.org

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -87,6 +87,7 @@ azlex.uz
 baixar-musicas-gratis.com
 baladur.ru
 balitouroffice.com
+balkanfarma.org
 bard-real.com.ua
 batut-fun.ru
 bavariagid.de


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.