### PR TITLE
Add alkanfarma.org

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -44,6 +44,7 @@ alfabot.xyz
 alibestsale.com
 aliexsale.ru
 alinabaniecka.pl
+alkanfarma.org
 allergick.com
 allknow.info
 allmarketsnewdayli.gdn


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.