### PR TITLE
Add rybalka-opt.ru

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -663,6 +663,7 @@ rusexy.xyz
 ruspoety.ru
 russian-postindex.ru
 russian-translator.com
+rybalka-opt.ru
 sad-torg.com.ua
 sady-urala.ru
 saltspray.ru


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.