### PR TITLE
Add we-ping-for-youic.info

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -850,6 +850,7 @@ vzubkah.com
 w3javascript.com
 wallpaperdesk.info
 wdss.com.ua
+we-ping-for-youic.info
 web-revenue.xyz
 webmaster-traffic.com
 webmonetizer.net


### PR DESCRIPTION
Showing up in Google Analytics as referrer spam. Started in July 2018.