### PR TITLE
Add free-website-traffic.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -326,6 +326,7 @@ free-social-buttons.xyz
 free-social-buttons7.xyz
 free-traffic.xyz
 free-video-tool.com
+free-website-traffic.com
 freenode.info
 freewhatsappload.com
 freewlan.info


### PR DESCRIPTION
Flooded my Matomo referral statistics. Redirects to verytraffic.com which offers fake visitors stats.