### PR TITLE
Add gepatit-info.top

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -338,6 +338,7 @@ gandikapper.ru
 gearcraft.us
 gearsadspromo.club
 generalporn.org
+gepatit-info.top
 germes-trans.com
 get-clickize.info
 get-free-social-traffic.com


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.