### PR TITLE
Add undergroundcityphoto.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -827,6 +827,7 @@ udav.net
 ufa.dienai.ru
 ukrainian-poetry.com
 ul-potolki.ru
+undergroundcityphoto.com
 unibus.su
 univerfiles.com
 unlimitdocs.net


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.