### PR TITLE
Add grafaman.ru

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -372,6 +372,7 @@ google-liar.ru
 googlemare.com
 googlsucks.com
 gorgaz.info
+grafaman.ru
 guardlink.org
 guidetopetersburg.com
 handicapvantoday.com


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.