### PR TITLE
Adds xtrafficplus.com, blogstar.fun

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -124,6 +124,7 @@ bizru.info
 black-friday.ga
 blackhatworth.com
 blog100.org
+blogstar.fun
 blogtotal.de
 blue-square.biz
 bluerobot.info
@@ -923,6 +924,7 @@ xn--d1abj0abs9d.in.ua
 xn--d1aifoe0a9a.top
 xn--e1aaajzchnkg.ru.com
 xn--e1agf4c.xn--80adxhks
+xtrafficplus.com
 xz618.com
 yaderenergy.ru
 yes-com.com


### PR DESCRIPTION
The actual spam referrer I saw was:
https://www.blogstar.fun/top-five-techniques-to-get-quick-visitors-to-site-and-make-money-quickly/50173724/

Blogstar.fun (both the full url above and the base domain) redirect to xtrafficplus.com