### PR TITLE
Add vardenafil20.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -880,6 +880,7 @@ uzpaket.com
 uzungil.com
 vaderenergy.ru
 validus.pro
+vardenafil20.com
 varikozdok.ru
 veloland.in.ua
 ventopt.by


### PR DESCRIPTION
This domain (scammy online pharmacy) has been appearing in multiple sites' referer logs over the last few days.  For example:

    5.188.210.3 - - [07/Dec/2018:00:12:35 +0000] "GET / HTTP/1.1" 301 521 "http://vardenafil20.com" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0.1 Safari/605.1.15"