### PR TITLE
Add kozhniebolezni.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -500,6 +500,7 @@ komputers-best.ru
 komukc.com.ua
 konkursov.net
 kozhasobak.com
+kozhniebolezni.com
 krasnodar-avtolombard.ru
 kredytbank.com.ua
 krumble-adsde.info


### PR DESCRIPTION
This domain (scammy online pharmacy) has been appearing in multiple sites' referer logs over the last few days. For example:

    46.118.119.245 - - [22/Dec/2018:14:58:05 +0000] "GET / HTTP/1.1" 301 521 "http://kozhniebolezni.com/" "Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 4.0; .NET CLR 1.0.2914)"
