### PR TITLE
added dailyseo.xyz to the list

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -247,6 +247,7 @@ cubook.supernew.org
 customsua.com.ua
 cyber-monday.ga
 dailyrank.net
+dailyseo.xyz
 darodar.com
 dawlenie.com
 dbutton.net


### PR DESCRIPTION
Spammer referrer: www.dailyseo.xyz for the link: https://www.dailyseo.xyz/beginner-s-guide-to-blogging-and-making-money-online/20240067/ Matomo is not getting it out.