### PR TITLE
Add sel-hoz.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -757,6 +757,7 @@ scripted.com
 search-error.com
 searchencrypt.com
 security-corporation.com.ua
+sel-hoz.com
 sell-fb-group-here.com
 semalt.com
 semaltmedia.com


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.