### PR TITLE
Add doggyhealthy.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -278,6 +278,7 @@ docsportal.net
 documentbase.net
 documentserver.net
 documentsite.net
+doggyhealthy.com
 dogsrun.net
 dojki-hd.com
 domain-tracker.com


### PR DESCRIPTION
Found in the logs of a German design freelancer. Dog site is not related in any way.