### PR TITLE
Add rustag.ru

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -761,6 +761,7 @@ rusexy.xyz
 ruspoety.ru
 russian-postindex.ru
 russian-translator.com
+rustag.ru
 rybalka-opt.ru
 sad-torg.com.ua
 sady-urala.ru


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.