### PR TITLE
Add psn-card.ru

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -720,6 +720,7 @@ pron.pro
 prosmibank.ru
 prostitutki-rostova.ru.com
 psa48.ru
+psn-card.ru
 punch.media
 purchasepillsnorx.com
 qualitymarketzone.com


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.