### PR TITLE
Add rustag.ru

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -718,9 +718,9 @@ pornoforadult.com
 pornogig.com
 pornohd1080.online
 pornoklad.ru
-pornoslave.net
 pornonik.com
 pornoplen.com
+pornoslave.net
 portnoff.od.ua
 pospektr.ru
 pozdravleniya-c.ru
@@ -784,6 +784,7 @@ ruspoety.ru
 russian-postindex.ru
 russian-translator.com
 russkie-sochineniya.ru
+rustag.ru
 rybalka-opt.ru
 s-forum.biz
 sad-torg.com.ua


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.