### PR TITLE
Add gelstate.ru

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -400,6 +400,7 @@ game300.ru
 gandikapper.ru
 gearcraft.us
 gearsadspromo.club
+gelstate.ru
 generalporn.org
 gepatit-info.top
 germes-trans.com


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.