### PR TITLE
Add lalalove.ru

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -552,6 +552,7 @@ kredytbank.com.ua
 krumble-adsde.info
 krumble-adsen.info
 krumbleent-ads.info
+lalalove.ru
 laminat.com.ua
 landliver.org
 landoftracking.com


### PR DESCRIPTION
Found in the logs of a website of a mathematics french tutor. The content, in english or russian, of the suspicious website is unrelated.