### PR TITLE
Remove duplicate entry

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -38,7 +38,6 @@
 8xv8.com
 9-best-seo.com
 99-reasons-for-seo.com
-99-reasons-for-seo.com
 abcdefh.xyz
 abcdeg.xyz
 abclauncher.com


### PR DESCRIPTION
Minor issue, but otherwise converting it to a Go map errors out:

    ./blacklist.go:47:2: duplicate key "99-reasons-for-seo.com" in map literal