### PR TITLE
Add axcus.top and xtraffic.plus

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -121,6 +121,7 @@ aviva-limoux.com
 avkzarabotok.info
 avtointeres.ru
 avtovykup.kz
+axcus.top
 azartclub.org
 azbukafree.com
 azlex.uz
@@ -1091,6 +1092,7 @@ xn--d1abj0abs9d.in.ua
 xn--d1aifoe0a9a.top
 xn--e1aaajzchnkg.ru.com
 xn--e1agf4c.xn--80adxhks
+xtraffic.plus
 xtrafficplus.com
 xz618.com
 yaderenergy.ru


### PR DESCRIPTION
axcus.top redirects to xtraffic.plus (a new domain of xtrafficplus.com, which is already in the blocklist).