### PR TITLE
Add artpress.top

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -102,6 +102,7 @@ artclipart.ru
 artdeko.info
 artpaint-market.ru
 artparquet.ru
+artpress.top
 aruplighting.com
 ask-yug.com
 atleticpharm.org


### PR DESCRIPTION
artpress.top redirects to xtraffic.plus (a new domain of xtrafficplus.com, which is already in the blocklist).