### PR TITLE
Block amylynnandrews.xyz

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -81,6 +81,7 @@ altermix.ua
 amazon-seo-service.com
 amt-k.ru
 amtel-vredestein.com
+amylynnandrews.xyz
 anabolics.shop
 anal-acrobats.hol.es
 analytics-ads.xyz


### PR DESCRIPTION
amylynnandrews.xyz redirects to xtraffic.plus (which is already in the blocklist).