### PR TITLE
Block samlaurabrown.top

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -825,6 +825,7 @@ s-forum.biz
 sad-torg.com.ua
 sady-urala.ru
 saltspray.ru
+samlaurabrown.top
 sanjosestartups.com
 santaren.by
 santasgift.ml


### PR DESCRIPTION
samlaurabrown.top redirects to xtraffic.plus (which is already in the blocklist).