### PR TITLE
Block squarespace.top

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -928,6 +928,7 @@ spin2016.cf
 sportwizard.ru
 spravka130.ru
 spravkavspb.net
+squarespace.top
 sribno.net
 sssexxx.net
 sta-grand.ru


### PR DESCRIPTION
squarespace.top redirects to xtraffic.plus (which is already in the blocklist).