### PR TITLE
Block selfhotdog.com and thesensehousehotel.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -841,6 +841,7 @@ search-error.com
 searchencrypt.com
 security-corporation.com.ua
 sel-hoz.com
+selfhotdog.com
 sell-fb-group-here.com
 semalt.com
 semaltmedia.com
@@ -971,6 +972,7 @@ tgtclick.com
 thaoduoctoc.com
 theautoprofit.ml
 theguardlan.com
+thesensehousehotel.com
 thesmartsearch.net
 tokshow.online
 tomck.com


### PR DESCRIPTION
These redirects to xtraffic.plus (which is already in the blocklist).