### PR TITLE
Block jeffbullas.xyz

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -517,6 +517,7 @@ jav-fetish.com
 jav-fetish.site
 javcoast.com
 javlibrary.cc
+jeffbullas.xyz
 jjbabskoe.ru
 jobius.com.ua
 josephineblog.top


### PR DESCRIPTION
This does a 302 redirect to xtraffic.plus which is already on the list.