### PR TITLE
Block hankspring.xyz

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -454,6 +454,7 @@ growth-hackingy.info
 guardlink.org
 guidetopetersburg.com
 handicapvantoday.com
+hankspring.xyz
 happysong.ru
 hard-porn.mobi
 havepussy.com


### PR DESCRIPTION
This does a 302 redirect to xtraffic.plus which is already on the list.