### PR TITLE
Block matomete.net

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -618,6 +618,7 @@ maridan.com.ua
 marinetraffic.com
 marketland.ml
 masterseek.com
+matomete.net
 matras.space
 mattgibson.us
 max-apprais.com


### PR DESCRIPTION
This does a 302 redirect to xtraffic.plus which is already on the list.