### PR TITLE
Block billyblog.online

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -157,6 +157,7 @@ bezprostatita.com
 bif-ru.info
 biglistofwebsites.com
 billiard-classic.com.ua
+billyblog.online
 bin-brokers.com
 bio-market.kz
 biplanecentre.ru


### PR DESCRIPTION
This does a 302 redirect to xtraffic.plus which is already on the list.