### PR TITLE
Block monicablog.xyz

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -855,6 +855,7 @@ money-for-placing-articles.com
 money7777.info
 moneytop.ru
 moneyzzz.ru
+monicablog.xyz
 moonci.ru
 mosrif.ru
 mostcool.top


### PR DESCRIPTION
This does a 302 redirect to xtraffic.plus which is already on the list.