### PR TITLE
Block lawrenceblog.online

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -758,6 +758,7 @@ law-enforcement-bot-ff.xyz
 law-enforcement-check-three.xyz
 law-enforcement-ee.xyz
 law-six.xyz
+lawrenceblog.online
 laxdrills.com
 leboard.ru
 ledalfa.by


### PR DESCRIPTION
This does a 302 redirect to xtraffic.plus which is already on the list.