### PR TITLE
Block carezi.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -263,6 +263,7 @@ buypillsonline24h.com
 buypuppies.ca
 call-of-duty.info
 cardiosport.com.ua
+carezi.com
 carivka.com.ua
 carscrim.com
 cartechnic.ru


### PR DESCRIPTION
This does a 302 redirect to xtraffic.plus which is already on the list.