### PR TITLE
Block georgeblog.online

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -541,6 +541,7 @@ gearcraft.us
 gearsadspromo.club
 gelstate.ru
 generalporn.org
+georgeblog.online
 gepatit-info.top
 germes-trans.com
 get-clickize.info


### PR DESCRIPTION
This does a 302 redirect to xtraffic.plus which is already on the list.