### PR TITLE
Block samanthablog.online

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -1104,6 +1104,7 @@ s-luna.me
 sad-torg.com.ua
 sady-urala.ru
 saltspray.ru
+samanthablog.online
 samara-airport.com
 samara-comfort.ru
 samchist.ru


### PR DESCRIPTION
This does a 302 redirect to xtraffic.plus which is already on the list.