### PR TITLE
Add firstblog.top

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -526,6 +526,7 @@ financial-simulation.com
 finansov.info
 finder.cool
 findercarphotos.com
+firstblog.top
 fix-website-errors.com
 flexderek.com
 floating-share-buttons.com


### PR DESCRIPTION
Redirect to the blacklisted xtrafficplus.com