### PR TITLE
Add bottraffic4free.club

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -271,6 +271,7 @@ bonus-vtb.ru
 books-top.com
 boostmyppc.com
 botamycos.fr
+bottraffic4free.club
 bottraffic4free.host
 bpro1.top
 brakehawk.com


### PR DESCRIPTION
Getting large amounts of "traffic" from bottraffic4free.club, saw that bottraffic4free.host was already added in the list where I've also gotten spam from. Both redirect to gammatraffic.com.