### PR TITLE
Add `shsupplychain.com`

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -1797,6 +1797,7 @@ shoppingmiracles.co.uk
 shoprybalka.ru
 shops-ru.ru
 shopsellcardsdumps.com
+shsupplychain.com
 shtaketniki.ru
 shtormmall.xyz
 shulepov.ru


### PR DESCRIPTION
`shsupplychain.com` redirects to `xtraffic.plus`, which is already on the list.


