### PR TITLE
Add `ierblog.xyz`

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -1006,6 +1006,7 @@ ico.re
 ideayz.com
 ieamblog.online
 ieeeoutlet.xyz
+ierblog.xyz
 igadgetsworld.com
 igamingtop.com
 igru-xbox.net


### PR DESCRIPTION
`ierblog.xyz` redirects to `xtraffic.plus`, which is already on the list.


