### PR TITLE
Add `kaegtcr.online`

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -1120,6 +1120,7 @@ kabinet-tinkoff.ru
 kabinet-tricolor.ru
 kabinet-ttk.ru
 kabinet-vtb24.ru
+kaegtcr.online
 kaircm.shop
 kakablog.net
 kakadu-interior.com.ua


### PR DESCRIPTION
`kaegtcr.online` redirects to `xtraffic.plus`, which is already on the list.


