### PR TITLE
Add `lyckants.online`

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -1239,6 +1239,7 @@ lumb.co
 luton-invest.ru
 luxup.ru
 luxurybet.ru
+lyckants.online
 madisonclothingny.com
 madjonline.xyz
 magicart.store


### PR DESCRIPTION
`lyckants.online` redirects to `uctraffic.com`, which is already on the list.


